### PR TITLE
Bug Fixes, UX Improvements, and Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+# Python
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 
 # Python
 __pycache__
+
+# MSP430 Assembly files
+*.asm
+
+# Output files
+*.hex
+*.txt

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ __pycache__
 # Output files
 *.hex
 *.txt
+
+
+# Editor
+# Visual Studio Code
+.vscode

--- a/assemble.py
+++ b/assemble.py
@@ -160,17 +160,17 @@ def asmMain(assembly, outfile=None, silent=False):
 				assemble(ins)
 			except IllegalOpcodeException as exp:
 				highlight = ins.replace(exp.opcode, f"[{exp.opcode}]")
-				print(f'Illegal opcode found on line {lineNumber + 1}: "{highlight}"')
+				print(f'Invalid opcode found on line {lineNumber + 1}: "{highlight}"')
 				sys.exit(-1)
 			except IllegalAddressingModeException as exp:
 				print(f'Addressing mode error found on line {lineNumber + 1}: "{exp.error}"')
 				sys.exit(-1)
 			except IllegalOffsetException as exp:
-				print(f'Illegal jump offset error found on line {lineNumber + 1}: "{exp.error}"')
+				print(f'Invalid jump offset error found on line {lineNumber + 1}: "{exp.error}"')
 				sys.exit(-1)
 			except InvalidRegisterException as exp:
 				highlight = ins.replace(exp.register, f"[{exp.register}]");
-				print(f'Illegal register mneumonic on line {lineNumber + 1}: "{highlight}"',
+				print(f'Invalid register mneumonic on line {lineNumber + 1}: "{highlight}"',
 					   'Valid registers are pc, sp, sr, cg, or r0-r15.', sep="\n")
 
 		lineNumber += 1

--- a/assemble.py
+++ b/assemble.py
@@ -1,16 +1,16 @@
 import sys
 import pdb
 
-jumpOpcodes = ['jne', 'jeq', 'jlo', 'jhs', 'jn ', 'jge', 'jl ', 'jmp']
+jumpOpcodes = ['jne', 'jeq', 'jlo', 'jhs', 'jn', 'jge', 'jl', 'jmp']
 twoOpOpcodes = ['!!!', '!!!', '!!!', '!!!', 'mov', 'add', 'addc', 'subc', 'sub', 'cmp', 'dadd', 'bit', 'bic', 'bis', 'xor', 'and']
 oneOpOpcodes = ['rrc', 'swpb', 'rra', 'sxt', 'push', 'call', 'reti']
 emulatedOpcodes = {
 'ret' : 'mov @sp+, pc',
-'clrc' : 'bic #1, sr', 
-'setc' : 'bis #1, sr', 
-'clrz' : 'bic #2, sr', 
-'setz' : 'bis #2, sr', 
-'clrn' : 'bic #4, sr', 
+'clrc' : 'bic #1, sr',
+'setc' : 'bis #1, sr',
+'clrz' : 'bic #2, sr',
+'setz' : 'bis #2, sr',
+'clrn' : 'bic #4, sr',
 'setn' : 'bis #4, sr',
 'dint' : 'bic #8, sr',
 'eint' : 'bis #8, sr',
@@ -29,6 +29,10 @@ emulatedOpcodes = {
 'adc'  : 'addc #0, {reg}',
 'dadc' : 'dadd #0, {reg}',
 'sbc'  : 'subc #0, {reg}',
+'jnc'  : 'jlo {reg}', #jlo, jhs are aliases of jnc, jc
+'jnz'  : 'jne {reg}', #jnz, jz are aliases of jne, jeq
+'jc'   : 'jhs {reg}',
+'jz'   : 'jeq {reg}',
 }
 
 def bitrep(number, bits = 16):
@@ -226,7 +230,7 @@ def assembleTwoOpInstruction(ins):
 	opcode, byteMode = getOpcode(ins)
 	out[0:4] = bitrep(twoOpOpcodes.index(opcode), 4)
 	out[9] = bitrep(byteMode, 1)
-	
+
 	#Find the location of the first operand
 	start = ins.find(' ') + 1
 	end = ins.find(',')

--- a/assemble.py
+++ b/assemble.py
@@ -372,7 +372,7 @@ def assembleRegister(reg, opcode=None, isDestReg = False):
 			extensionWord = 0
 		else:
 			adrmode = 2
-			regID = getRegister(reg[reg.find('@') : ])
+			regID = getRegister(reg[reg.find('@')+1 : ])
 	elif '#' in reg: #Use PC to specify an immediate constant
 		if isDestReg:
 			raise IllegalAddressingModeException(0, reg)

--- a/assemble.py
+++ b/assemble.py
@@ -164,15 +164,18 @@ def asmMain(assembly, outfile=None, silent=False):
 	if outFP:
 		outFP.close()
 
+def hex_to_int(hex_string: str, byteorder = 'little') -> int:
+	return int.from_bytes(bytes=bytes.fromhex(hex_string), byteorder=byteorder)
 
-
-def registerLabel(ins):
+def registerLabel(ins: str):
 	global labels #Get labels
 	global PC #Get PC
-	label = ins[0 : ins.find(':')]
+	label, addr = ins.split(sep=":")
 	if label in labels.keys():
 		raise AlreadyDefinedLabelException(label)
 	labels[label] = PC
+	if addr: #Allow label addresses to be manually set by the user
+		labels[label] = hex_to_int(addr.strip(), 'big')
 
 def registerJumpInstruction(PC, label):
 	global jumps #Get jump instructions

--- a/assemble.py
+++ b/assemble.py
@@ -301,10 +301,11 @@ def assembleJumpInstruction(ins):
 
 
 
-def getRegister(registerName):
+def getRegister(registerName: str):
 	"""Decodes special register names (or normal register names)."""
+	registerName = registerName.strip().lower() #Strip leading and trailing whitespace, and convert to lowercase
 	specialRegisterNames = ['pc', 'sp', 'sr', 'cg']
-	if registerName.lower() in specialRegisterNames:
+	if registerName in specialRegisterNames:
 		return specialRegisterNames.index(registerName)
 	else:
 		return int(registerName[1:]) #Remove 'r'

--- a/assemble.py
+++ b/assemble.py
@@ -223,7 +223,7 @@ def assembleOneOpInstruction(ins):
 	#We need to provide the opcode here to detect the push bug; see the function itself
 	extensionWord, adrmode, regID = assembleRegister(reg, opcode=opcode)
 
-	out[11:12] = bitrep(adrmode, 2)
+	out[10:12] = bitrep(adrmode, 2)
 	out[12:] = bitrep(regID, 4)
 	appendWord(int(''.join(str(e) for e in out), 2))
 	if extensionWord:

--- a/assemble.py
+++ b/assemble.py
@@ -185,7 +185,6 @@ def asmMain(assembly, outfile=None, silent=False):
 
 		#Handle .directives
 		if ins.startswith('.'):
-			#Allow
 			if ins.startswith(".define"):
 				registerDefine(ins)
 			#Allow passing the .end directive in input files, for compatibility with stdin input
@@ -450,7 +449,7 @@ def getOpcode(ins: str):
 		byteMode = True
 	return opcode, byteMode
 
-def appendWord(word):
+def appendWord(word: int):
 	"""Add a word to the output instruction stream, handling little endian format."""
 	global PC #Get PC
 	global output #Get output
@@ -459,7 +458,7 @@ def appendWord(word):
 	output.append(int(strword[2:] + strword[0:2], 16))
 	PC += 1
 
-def assembleRegister(reg, opcode=None, isDestReg = False):
+def assembleRegister(reg: str, opcode=None, isDestReg = False):
 	"""Assembles an operand, returning the extension word used (if applicable),
 	the addressing mode, and the register ID."""
 	extensionWord = None
@@ -484,13 +483,13 @@ def assembleRegister(reg, opcode=None, isDestReg = False):
 			extensionWord = 0
 		else:
 			adrmode = 2
-			regID = getRegister(reg[reg.find('@')+1 : ])
+			regID = getRegister(reg[reg.find('@') + 1 : ])
 	elif '#' in reg: #Use PC to specify an immediate constant
 		if isDestReg:
 			raise IllegalAddressingModeException(0, reg)
 		adrmode = 3
 		regID = 0
-		constant = reg[reg.find('#') + 1 :]
+		constant = reg[reg.find('#') + 1 :].strip()
 
 		#This might be an immediate constant supported by the hardware
 

--- a/assemble.py
+++ b/assemble.py
@@ -55,6 +55,10 @@ def hexrep(number, zeroes = 4):
 	leading0s = zeroes - hexcount
 	return ('0' * leading0s) + hexstr
 
+def highlight(string: str, substring: str) -> str:
+	"""Highlight a substring in a string"""
+	return string.replace(substring, f"\033[4m{substring}\033[0m") if substring else string
+
 class AssemblyError(Exception):
 	"""
 	The base class for all Assembly Exceptions
@@ -203,7 +207,7 @@ def asmMain(assembly, outfile=None, silent=False):
 		if ':' in ins:
 			try:
 				registerLabel(ins)
-			except AlreadyDefinedLabelException as exp:
+			except RedefinedLabelError as exp:
 				print('Label "' + exp.label + '" at line number ' + str(lineNumber + 1) + ' already defined')
 				sys.exit(-1)
 		else:
@@ -212,7 +216,7 @@ def asmMain(assembly, outfile=None, silent=False):
 			except AssemblyError as exp:
 				ins = highlight(ins, exp.name)
 				print(f'{exp.type} found on line {lineNumber + 1}: "{ins}"\n{exp.reason}')
-				if not allowFail: sys.exit(-1)
+				sys.exit(-1)
 
 		lineNumber += 1
 

--- a/assemble.py
+++ b/assemble.py
@@ -187,7 +187,7 @@ def asmMain(assembly, outfile=None, silent=False):
 		ins = ins.strip()
 		ins = re.split(r'\s*[/;]', ins)[0] #Remove comments
 		#Skip empty lines or lines beginning with a comment
-		if len(ins) == 0 or ins.startswith((';', '//')):
+		if len(ins) == 0:
 			continue
 
 		#Handle .directives

--- a/assemble.py
+++ b/assemble.py
@@ -145,16 +145,6 @@ labels = {} #Label name and its PC location
 """
 `labels` are a label name, followed by a the address of the label relative to the loadaddr
 """
-defines = {} #Define name and its corresponding value
-"""
-`defines` are a search string and a replace string.
-
-Example:
-```MSProbe
-.define foo bar
-```
-defines: {"foo": "bar"}
-"""
 jumps = {} #PC location of jump and its corresponding label
 """
 `jumps` are the address of a jump instruction and its corresponding label
@@ -198,6 +188,9 @@ def asmMain(assembly, outfile=None, silent=False):
 			#Allow
 			if ins.startswith(".define"):
 				registerDefine(ins)
+			#Allow passing the .end directive in input files, for compatibility with stdin input
+			if ins.startswith(".end"):
+				break
 			continue
 
 		#Handle preprocessor substitution hooks

--- a/assemble.py
+++ b/assemble.py
@@ -281,9 +281,9 @@ def registerLabel(ins: str):
 
 # -- Defines --
 def resolveDefines(ins: str) -> str:
-	global defines
-	for define in defines:
-		ins = ins.replace(define, defines[define])
+	global _defines
+	for define in _defines:
+		ins = ins.replace(define, _defines[define])
 	return ins
 
 def registerDefine(ins: str):
@@ -293,15 +293,15 @@ def registerDefine(ins: str):
 	```asm
 	.define identifier text...
 	"""
-	global defines, preprocessorHooks
+	global _defines, preprocessorHooks
 	if 'defines' not in globals():
-		defines = {}
+		_defines = {}
 	#Define is of format .define [identifier] [any text]
 	#Space(s) not required, but if spaces are not used, ':' or '=' must be used in its place
 	define: tuple = re.match(r'.define\s*(\w+)[\s:=]+(.*)\s*', ins).groups()
 	if define != ():
 		label, replacement = define
-		defines[label] = replacement
+		_defines[label] = replacement
 		registerPreprocessorHook(resolveDefines)
 
 def registerJumpInstruction(PC, label):

--- a/assemble.py
+++ b/assemble.py
@@ -290,7 +290,7 @@ def registerDefine(ins: str):
 	.define identifier text...
 	"""
 	global _defines, preprocessorHooks
-	if 'defines' not in globals():
+	if '_defines' not in globals():
 		_defines = {}
 	#Define is of format .define [identifier] [any text]
 	#Space(s) not required, but if spaces are not used, ':' or '=' must be used in its place

--- a/assemble.py
+++ b/assemble.py
@@ -282,7 +282,6 @@ def registerLabel(ins: str):
 	label, addr = ins.split(sep=':')
 	if label in labels:
 		raise AlreadyDefinedLabelException(label)
-	registerPostprocessorHook(resolveJumps)
 
 # -- Defines --
 def resolveDefines(ins: str) -> str:
@@ -313,6 +312,7 @@ def registerJumpInstruction(PC, label):
 	"""Defer jump offset calculation until labels are defined"""
 	global jumps #Get jump instructions
 	jumps[PC] = label
+	registerPostprocessorHook(resolveJumps)
 
 def assemble(ins):
 	"""Assemble a single instruction, and append results to the output stream."""

--- a/assemble.py
+++ b/assemble.py
@@ -164,10 +164,10 @@ def asmMain(assembly, outfile=None, silent=False):
 		#Provide a prompt for entry
 		instructions = ''
 		ins = ''
-		print('Input assembly. Terminate input with the ".end" directive.')
+		print('Input assembly. Terminate input with the ".end" directive, or Ctrl+D (EOF).')
 		while True:
 			ins = sys.stdin.readline()
-			if ins == '.end\n':
+			if ins == '.end\n' or ins == '':
 				break
 			instructions = instructions + ins
 	else:

--- a/assemble.py
+++ b/assemble.py
@@ -108,6 +108,12 @@ def asmMain(assembly, outfile=None, silent=False):
 
 
 	for ins in instructions.splitlines():
+		#Strip leading and trailing whitespace
+		ins = ins.strip()
+		#Skip empty lines or lines beginning with a comment
+		if len(ins) == 0 or ins.startswith((';', '//')):
+			continue
+
 		if ':' in ins:
 			try:
 				registerLabel(ins)

--- a/assemble.py
+++ b/assemble.py
@@ -428,10 +428,10 @@ def getRegister(registerName: str):
 	if registerName in specialRegisterNames:
 		return specialRegisterNames[registerName]
 	elif registerName.startswith('r'):
-		#FIXME: this allows registers with any integer name
-		return int(registerName[1:]) #Remove 'r'
-	else:
-		raise RegisterError(registerName)
+		register = int(registerName[1:]) #Remove 'r'
+		if register in range(16):
+			return register
+	raise RegisterError(registerName)
 
 def getOpcode(ins: str):
 	"""Returns the opcode and whether byte mode is being used."""

--- a/msprobe.py
+++ b/msprobe.py
@@ -36,7 +36,7 @@ Microcorruption hex dump.')
 	disasmParser.add_argument('disassembly', default=None, nargs='?')
 	disasmParser.add_argument('-mc', '--microcorruptionparse', action='store_true')
 	disasmParser.set_defaults(microcorruptionparse=False)
-	disasmParser.set_defaults(disasm = True) #Let us know we're running in disasm mode
+	disasmParser.set_defaults(disasmdummy = True) #Let us know we're running in disasm mode
 
 	asmParser = subparser.add_parser('asm', help='File to read assembly code from. \
 If not provided, a prompt will be provided to read from sys.stdin.')
@@ -52,7 +52,7 @@ If not provided, a prompt will be provided to read from sys.stdin.')
 		args = parser.parse_args(arguments.split())
 
 	try: #Figure out what mode we're running in
-		args.disasm
+		args.disasmdummy
 		disasmMode = True
 	except AttributeError:
 		disasmMode = False

--- a/msprobe.py
+++ b/msprobe.py
@@ -81,11 +81,13 @@ def disasmMain(disassembly, pcBase=0, microcorruptionparse=False, outfile=None, 
 	outFP = open(outfile, 'w') if outfile else None
 
 	strinput = ''.join(strinput.split()) #First, let's remove spaces.
-	for i in range(0, len(strinput), 4):
-		part1 = strinput[i] + strinput[i + 1]
-		part2 = strinput[i + 2] + strinput[i + 3]
-		#Append word in little-endian format
-		asm.append(int((part2 + part1), 16))
+
+	#Then, convert each word from little-endian and append to the asm list
+	asm.extend([
+		(
+			int.from_bytes(bytes=bytes.fromhex(strinput[i:i+4]), byteorder='little')
+		)for i in range(0, len(strinput), 4)
+	])
 
 	while PC <= len(asm) - 1: #array index<->array length so - 1
 		ins = asm[PC]
@@ -159,7 +161,7 @@ def disassemble(instruction):
 	if ins[0:3] == '001':
 		return disassembleJumpInstruction(ins)
 	elif ins[0:6] == '000100':
-	  	return disassembleOneOpInstruction(ins)
+		return disassembleOneOpInstruction(ins)
 	else:
 		return disassembleTwoOpInstruction(ins)
 
@@ -346,14 +348,14 @@ def disassembleAddressingMode(reg, adrmode):
 	elif adrmode == 1:
 		regOutput = adrModes[adrmode].format(register=registerNames[reg], index=hex(asm[PC + 1]))
 		extensionWord = True
-	
+
 	elif adrmode == 2:
 		regOutput = adrModes[adrmode].format(register=registerNames[reg])
-	
+
 	elif adrmode == 3 and reg == 0: #PC was incremented for a constant
 		regOutput = '#' + hex(asm[PC + 1])
 		extensionWord = True
-	
+
 	elif adrmode == 3:
 		regOutput = adrModes[adrmode].format(register=registerNames[reg])
 


### PR DESCRIPTION
# Changelog:

## Assembler:

### Bug fixes:
- Instruction Encoding
  - Encodes addressing mode for one-operand instructions properly (off-by-one in slice)
  - Fix off-by-one in indirect addressing mode register
  - Check if jump offset is within the valid range when assembling jump instructions

### UX Improvements:
- Pre-processor:
  - Removes comments before parsing line
  - Trims leading spaces, allowing for meaningful indentation in asm files
  - Accepts .define statements with syntax `.define identifier [any text]` to allow embedding of constants
  - Accepts .end statements during line parsing, to allow assembler to be aborted early when assembling from a file
- Instruction Encoding:
  - Accepts alternate mnemonics for `jlo`  (`jnc`), `jne` (`jnz`), `jhs` (`jc`), `jeq` (`jz`)
  - Produces useful output when encountering an error, including the exact token that caused the error when available
  - Provides a unique reason for failure, which makes using MSProbe for payload development easier
- Post-processor:
  - Runs jump label offset calculation only if jump labels are used

### Cleanup:
- Style:
  - Uses type annotations where it's not obvious what types are accepted
  - Keeps typing consistent throughout functions
  - Uses PEP-8-style exception names (i.e. `JumpOffsetError` instead of `IllegalOffsetException`)
- Instruction Decoding
  - Uses `re.split` to find the opcode sans `.b`/`.w`, simplifying instruction decoding
  - Uses regex matching to determine whether a jump offset is a label or a number
    - This syntactically changes relative jumps by making the leading '+' optional.
    - This has the side effect of making labels which consist of only hexadecimal digits (i.e. `a123:`) inaccessible.

## Disassembler:

### Bug fixes:
  - Initializes `pcBase` to 0 if not provided as CLI arg, which allows the disassembler to continue if the optional loadaddr arg isn't provided

### UX improvements:
  - Replaces the `!!!` with the original byte sequence if an invalid instruction is returned, (i.e. `!!! r0, r0`)
  - Exits with a cancellation message instead of unwinding the stack when receiving SIGINT

### Cleanup:
  - Rework byte-order conversion to use Python's built-in conversion functions instead of hand-rolled solution
