### PR TITLE
Bug fixes

### DIFF
--- a/assemble.py
+++ b/assemble.py
@@ -213,7 +213,7 @@ def assembleOneOpInstruction(ins):
 	#We need to provide the opcode here to detect the push bug; see the function itself
 	extensionWord, adrmode, regID = assembleRegister(reg, opcode=opcode)
 
-	out[11:12] = bitrep(adrmode, 2)
+	out[10:12] = bitrep(adrmode, 2)
 	out[12:] = bitrep(regID, 4)
 	appendWord(int(''.join(str(e) for e in out), 2))
 	if extensionWord:
@@ -288,6 +288,8 @@ def assembleJumpInstruction(ins):
 		offset = int(dest, 16)
 		if offset % 2 != 0:
 			raise IllegalOffsetException(offset)
+		if offset <= -0x3fe or offset >= 0x400:
+			raise IllegalOffsetException(offset)
 		#Jump offsets are multiplied by two, added by two (PC increment), and sign extended
 		out[6:] = bitrep((offset - 2) // 2, 10)
 	else:
@@ -358,7 +360,7 @@ def assembleRegister(reg, opcode=None, isDestReg = False):
 			extensionWord = 0
 		else:
 			adrmode = 2
-			regID = getRegister(reg[reg.find('@') : ])
+			regID = getRegister(reg[reg.find('@') + 1 : ])
 	elif '#' in reg: #Use PC to specify an immediate constant
 		if isDestReg:
 			raise IllegalAddressingModeException(0, reg)

--- a/assemble.py
+++ b/assemble.py
@@ -1,7 +1,7 @@
 import sys
 import pdb
 
-jumpOpcodes = ['jne', 'jeq', 'jlo', 'jhs', 'jn ', 'jge', 'jl ', 'jmp']
+jumpOpcodes = ['jne', 'jeq', 'jlo', 'jhs', 'jn', 'jge', 'jl', 'jmp']
 twoOpOpcodes = ['!!!', '!!!', '!!!', '!!!', 'mov', 'add', 'addc', 'subc', 'sub', 'cmp', 'dadd', 'bit', 'bic', 'bis', 'xor', 'and']
 oneOpOpcodes = ['rrc', 'swpb', 'rra', 'sxt', 'push', 'call', 'reti']
 emulatedOpcodes = {
@@ -29,6 +29,10 @@ emulatedOpcodes = {
 'adc'  : 'addc #0, {reg}',
 'dadc' : 'dadd #0, {reg}',
 'sbc'  : 'subc #0, {reg}',
+'jnc'  : 'jlo {reg}', #jlo, jhs are aliases of jnc, jc
+'jnz'  : 'jne {reg}', #jnz, jz are aliases of jne, jeq
+'jc'   : 'jhs {reg}',
+'jz'   : 'jeq {reg}',
 }
 
 def bitrep(number, bits = 16):

--- a/assemble.py
+++ b/assemble.py
@@ -6,11 +6,11 @@ twoOpOpcodes = ['!!!', '!!!', '!!!', '!!!', 'mov', 'add', 'addc', 'subc', 'sub',
 oneOpOpcodes = ['rrc', 'swpb', 'rra', 'sxt', 'push', 'call', 'reti']
 emulatedOpcodes = {
 'ret' : 'mov @sp+, pc',
-'clrc' : 'bic #1, sr', 
-'setc' : 'bis #1, sr', 
-'clrz' : 'bic #2, sr', 
-'setz' : 'bis #2, sr', 
-'clrn' : 'bic #4, sr', 
+'clrc' : 'bic #1, sr',
+'setc' : 'bis #1, sr',
+'clrz' : 'bic #2, sr',
+'setz' : 'bis #2, sr',
+'clrn' : 'bic #4, sr',
 'setn' : 'bis #4, sr',
 'dint' : 'bic #8, sr',
 'eint' : 'bis #8, sr',
@@ -226,7 +226,7 @@ def assembleTwoOpInstruction(ins):
 	opcode, byteMode = getOpcode(ins)
 	out[0:4] = bitrep(twoOpOpcodes.index(opcode), 4)
 	out[9] = bitrep(byteMode, 1)
-	
+
 	#Find the location of the first operand
 	start = ins.find(' ') + 1
 	end = ins.find(',')

--- a/msprobe.py
+++ b/msprobe.py
@@ -11,6 +11,7 @@ import argparse
 import sys
 import pdb
 
+from signal import signal, SIGINT
 from assemble import asmMain
 
 PC = 0 #Incremented by each disassembled instruction, incremented in words NOT bytes
@@ -303,6 +304,8 @@ def disassembleTwoOpInstruction(ins):
 	if reassembleins:
 		finalins = opcode + bytemode + ' ' + (regOutputDst if usesDest else regOutputSrc)
 
+	if '!!!' in finalins:
+		finalins = finalins.replace('!!!', f'!{int(ins,2):04x}!')
 	return finalins
 
 
@@ -360,4 +363,5 @@ def disassembleAddressingMode(reg, adrmode):
 	return (regOutput, extensionWord)
 
 if __name__ == '__main__':
+	signal(SIGINT, lambda *args: print('\nAction cancelled by user.') + exit(0))
 	main()

--- a/msprobe.py
+++ b/msprobe.py
@@ -57,7 +57,7 @@ If not provided, a prompt will be provided to read from sys.stdin.')
 		disasmMode = False
 
 	if disasmMode:
-		if args.loadaddr == '' and args.microcorruptionparse: #We might have read loadaddr from -mc instead
+		if args.loadaddr == '' or args.microcorruptionparse: #We might have read loadaddr from -mc instead
 			pcBase = 0
 		else:
 			pcBase = int(args.loadaddr, 16)

--- a/msprobe.py
+++ b/msprobe.py
@@ -159,7 +159,7 @@ def disassemble(instruction):
 	if ins[0:3] == '001':
 		return disassembleJumpInstruction(ins)
 	elif ins[0:6] == '000100':
-	  	return disassembleOneOpInstruction(ins)
+		return disassembleOneOpInstruction(ins)
 	else:
 		return disassembleTwoOpInstruction(ins)
 
@@ -346,14 +346,14 @@ def disassembleAddressingMode(reg, adrmode):
 	elif adrmode == 1:
 		regOutput = adrModes[adrmode].format(register=registerNames[reg], index=hex(asm[PC + 1]))
 		extensionWord = True
-	
+
 	elif adrmode == 2:
 		regOutput = adrModes[adrmode].format(register=registerNames[reg])
-	
+
 	elif adrmode == 3 and reg == 0: #PC was incremented for a constant
 		regOutput = '#' + hex(asm[PC + 1])
 		extensionWord = True
-	
+
 	elif adrmode == 3:
 		regOutput = adrModes[adrmode].format(register=registerNames[reg])
 


### PR DESCRIPTION
Bug Fixes:

`msprobe.py`:
- Default loadaddr was left undefined unless `-mc` passed

`assemble.py`:
- Off-by-one in `assembleOneOpInstruction` slice index produced incorrect machine code
- Off-by-one in `assembleRegister` Indirect Source mode produced invalid register name
- Numeric jump offsets outside valid range would be accepted
- Jump offsets without a leading `+` or `-` would always be treated as labels since `[0-9]` is alphanumeric
- Crash when parsing blank or comment-only lines
- Invalid register encoding produced by  extensionWord type error in `AssembleRegister` (object is string, not int)

Formatting improvement:
- Fixed mixed spaces/tabs
- Fixed trailing whitespace